### PR TITLE
Fix chat message orientation and add avatars

### DIFF
--- a/apps/web/components/MessageBubble.tsx
+++ b/apps/web/components/MessageBubble.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Card, CardBody } from '@heroui/react';
 import { useAppStore } from '@/lib/store';
+import { useAuth } from '@/lib/auth';
 export type Msg = import('@/lib/store').Msg;
 
 const Check = ({ double }: { double?: boolean }) => (
@@ -10,17 +11,49 @@ const Check = ({ double }: { double?: boolean }) => (
 );
 
 export default function MessageBubble({ msg }: { msg: Msg }) {
-  const mine = (msg as any).author === 'me' || msg.authorId === 'me';
-  const peerSeenAt = useAppStore(s => s.peerReadAt[msg.roomId] ?? 0);
+  const me = useAuth((s) => s.user);
+  const mine = String(me?.id) === msg.authorId;
+  const peerSeenAt = useAppStore((s) => s.peerReadAt[msg.roomId] ?? 0);
   const seen = mine && peerSeenAt >= msg.at;
 
+  const avatar = (
+    <div
+      className={[
+        'w-8 h-8 rounded-full flex items-center justify-center font-bold mx-2',
+        mine ? 'bg-primary text-primary-foreground' : 'bg-content3 text-foreground',
+      ].join(' ')}
+    >
+      {msg.authorName?.[0]?.toUpperCase()}
+    </div>
+  );
+
   return (
-    <div className={['w-full flex', mine ? 'justify-end' : 'justify-start'].join(' ')}>
-      <Card radius="lg" className={['max-w-[70%]', mine ? 'bg-primary text-primary-foreground' : 'bg-content2'].join(' ')}>
+    <div
+      className={[
+        'w-full flex items-end',
+        mine ? 'justify-end flex-row-reverse' : 'justify-start',
+      ].join(' ')}
+    >
+      {avatar}
+      <Card
+        radius="lg"
+        className={[
+          'max-w-[70%]',
+          mine ? 'bg-primary text-primary-foreground' : 'bg-content2',
+        ].join(' ')}
+      >
         <CardBody className="px-3 py-2">
           <div className="whitespace-pre-wrap break-words">{msg.text}</div>
-          <div className={['text-tiny mt-1 opacity-80', mine ? 'text-primary-foreground' : 'text-foreground-500'].join(' ')}>
-            {new Date(msg.at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          <div
+            className={[
+              'text-tiny mt-1 opacity-80',
+              mine ? 'text-primary-foreground' : 'text-foreground-500',
+            ].join(' ')}
+          >
+            {new Date(msg.at).toLocaleTimeString([], {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
             {mine ? <Check double={seen} /> : null}
           </div>
         </CardBody>

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -112,7 +112,12 @@ export const useAppStore = create<State>((set, get) => ({
       console.log("socket connected", s.id);
       await get().requestRooms();
       const current = get().currentRoomId;
-      if (current) s.emit("room:join", { roomId: current });
+      if (current) {
+        s.emit("room:join", { roomId: current });
+        if (!get().messages[current]?.length) {
+          s.emit("chat:history:get", { roomId: current, limit: 50 });
+        }
+      }
     });
 
     s.on("connect_error", (e) => console.warn("socket error", e.message));


### PR DESCRIPTION
## Summary
- ensure history loads after reconnecting to chat
- determine own messages via current user id and show user initials as avatar

## Testing
- `npm test`
- `cd apps/web && npm run lint` *(fails: Cannot find package '@eslint/compat')*

------
https://chatgpt.com/codex/tasks/task_e_68ae4435987c832cace6ddca9e79d41f