### PR TITLE
Refactor auth API DB setup with optional SSL

### DIFF
--- a/apps/auth-api/src/db.js
+++ b/apps/auth-api/src/db.js
@@ -1,0 +1,35 @@
+import pg from 'pg';
+
+const { Pool } = pg;
+
+export const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : undefined,
+});
+
+export async function waitForDB(maxAttempts = 30, delayMs = 2000) {
+  for (let i = 1; i <= maxAttempts; i++) {
+    try {
+      await pool.query('SELECT 1');
+      console.log('DB connection OK');
+      return;
+    } catch (e) {
+      console.log(`DB not ready (${i}/${maxAttempts})…`, e.code || e.message);
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  console.error('DB is not reachable, exiting');
+  process.exit(1);
+}
+
+export async function ensureUserTable() {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      id BIGSERIAL PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      name TEXT NOT NULL,
+      password_hash TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT now()
+    );
+  `);
+}

--- a/apps/auth-api/src/index.js
+++ b/apps/auth-api/src/index.js
@@ -3,82 +3,69 @@ import express from 'express';
 import cors from 'cors';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
-import pg from 'pg';
+import { pool, waitForDB, ensureUserTable } from './db.js';
 
 const app = express();
-const port = process.env.PORT || 5001;
-const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const port = Number(process.env.PORT) || 5001;
 const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret';
 const CORS_ORIGIN = process.env.CORS_ORIGIN || '*';
 
 app.use(cors({ origin: CORS_ORIGIN, credentials: true }));
 app.use(express.json());
 
-async function waitForDB(maxAttempts = 30, delayMs = 2000) {
-for (let i = 1; i <= maxAttempts; i++) {
-try {
-await pool.query('SELECT 1');
-console.log('DB connection OK');
-return;
-} catch (e) {
-console.log(`DB not ready (${i}/${maxAttempts})…`, e.code || e.message);
-await new Promise(r => setTimeout(r, delayMs));
-}
-}
-console.error('DB is not reachable, exiting');
-process.exit(1);
+function signUser(user) {
+  return jwt.sign(
+    { sub: String(user.id), email: user.email, name: user.name },
+    JWT_SECRET,
+    { expiresIn: '7d' }
+  );
 }
 
+function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
 
 await waitForDB();
+await ensureUserTable();
 
-// Инициализация таблицы пользователей при старте
-await pool.query(`
-  CREATE TABLE IF NOT EXISTS users (
-    id BIGSERIAL PRIMARY KEY,
-    email TEXT UNIQUE NOT NULL,
-    name TEXT NOT NULL,
-    password_hash TEXT NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT now()
-  );
-`);
-
-function signUser(user) {
-  return jwt.sign({ sub: String(user.id), email: user.email, name: user.name }, JWT_SECRET, { expiresIn: '7d' });
-}
-
-app.post('/auth/register', async (req, res) => {
-  try {
-    const { email, name, password } = req.body;
-    if (!email || !name || !password) return res.status(400).json({ error: 'email, name, password are required' });
-    const hash = await bcrypt.hash(password, 10);
-    const q = await pool.query('INSERT INTO users(email, name, password_hash) VALUES($1,$2,$3) RETURNING id, email, name, created_at', [email.toLowerCase(), name, hash]);
-    const user = q.rows[0];
-    const token = signUser(user);
-    res.json({ token, user });
-  } catch (e) {
-    if (e.code === '23505') return res.status(409).json({ error: 'Email already registered' });
-    console.error(e);
-    res.status(500).json({ error: 'Internal error' });
+app.post('/auth/register', asyncHandler(async (req, res) => {
+  const { email, name, password } = req.body;
+  if (!email || !name || !password) {
+    return res.status(400).json({ error: 'email, name, password are required' });
   }
-});
-
-app.post('/auth/login', async (req, res) => {
+  const hash = await bcrypt.hash(password, 10);
+  let user;
   try {
-    const { email, password } = req.body;
-    if (!email || !password) return res.status(400).json({ error: 'email, password are required' });
-    const q = await pool.query('SELECT * FROM users WHERE email=$1', [email.toLowerCase()]);
-    const user = q.rows[0];
-    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
-    const ok = await bcrypt.compare(password, user.password_hash);
-    if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
-    const token = signUser(user);
-    res.json({ token, user: { id: user.id, email: user.email, name: user.name } });
+    const q = await pool.query(
+      'INSERT INTO users(email, name, password_hash) VALUES($1,$2,$3) RETURNING id, email, name, created_at',
+      [email.toLowerCase(), name, hash]
+    );
+    user = q.rows[0];
   } catch (e) {
-    console.error(e);
-    res.status(500).json({ error: 'Internal error' });
+    if (e.code === '23505') {
+      return res.status(409).json({ error: 'Email already registered' });
+    }
+    throw e;
   }
-});
+  const token = signUser(user);
+  res.json({ token, user });
+}));
+
+app.post('/auth/login', asyncHandler(async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ error: 'email, password are required' });
+  }
+  const q = await pool.query('SELECT * FROM users WHERE email=$1', [email.toLowerCase()]);
+  const user = q.rows[0];
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+  const ok = await bcrypt.compare(password, user.password_hash);
+  if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = signUser(user);
+  res.json({ token, user: { id: user.id, email: user.email, name: user.name } });
+}));
 
 app.get('/auth/me', (req, res) => {
   try {
@@ -87,9 +74,14 @@ app.get('/auth/me', (req, res) => {
     if (!token) return res.status(401).json({ error: 'No token' });
     const payload = jwt.verify(token, JWT_SECRET);
     res.json({ user: { id: payload.sub, email: payload.email, name: payload.name } });
-  } catch (e) {
+  } catch {
     return res.status(401).json({ error: 'Invalid token' });
   }
+});
+
+app.use((err, _req, res, _next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal error' });
 });
 
 app.listen(port, () => console.log('auth-api on :' + port));


### PR DESCRIPTION
## Summary
- extract PostgreSQL pool and schema helpers into `db.js`
- wrap express routes with async handler and central error handler
- support `PGSSLMODE=require` for connecting to SSL-only databases

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af0c378eb0832cb786f811315080c4